### PR TITLE
Correct solar radiation NaN value

### DIFF
--- a/src/lisvap/__init__.py
+++ b/src/lisvap/__init__.py
@@ -1,7 +1,7 @@
-version = version = (1, 2, 5)
+version = version = (1, 2, 6)
 __authors__ = "Peter Burek, Johan van der Knijff, Ad de Roo"
 __version__ = '.'.join(list(map(str, version)))
-__date__ = "19/07/2022"
+__date__ = "16/03/2023"
 __copyright__ = "Copyright 2020, Lisflood Open Source"
 __maintainers__ = "Goncalo Gomes, Domenico Nappo, Valerio Lorini, Lorenzo Mentaschi, Lorenzo Alfieri"
 __status__ = "Operation"

--- a/src/lisvap/utils/readers.py
+++ b/src/lisvap/utils/readers.py
@@ -232,7 +232,7 @@ def readnetcdf(name, timestep, timestampflag='closest', averageyearflag=False, v
     nf1.close()
     nan_value = -9999
     if variable_name == 'rn':
-        nan_value = -9999999
+        nan_value = -99999999
     mapnp[np.isnan(mapnp)] = nan_value
     mapnp = numpy_operations.numpy2pcr(Scalar, mapnp, nan_value)
     timename = os.path.basename(name_parameter) + str(timestep)


### PR DESCRIPTION
Solar Radiation maps for GLOFAS can have values of -9999999, therefore this value is not acceptable as NaN, that is why we had to change the value to-99999999 .